### PR TITLE
Add hex meta info

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,8 @@ defmodule KafkaEx.Mixfile do
     [app: :kafka_ex,
      version: "0.0.1",
      elixir: "~> 1.0",
+     description: description,
+     package: package,
      deps: deps]
   end
 
@@ -21,5 +23,15 @@ defmodule KafkaEx.Mixfile do
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},
     ]
+  end
+
+  defp description do
+    "Kafka client for Elixir/Erlang."
+  end
+
+  defp package do
+    [contributors: ["Jack Lund"],
+     files: ["lib", "mix.exs", "README.md"],
+     links: %{"Github" => "https://github.com/jacklund/kafka_ex"}]
   end
 end


### PR DESCRIPTION
Meta info for hex.pm site. I don't know license, you can add it with `licenses: ["MIT"]` to `package` function, where *MIT* is your license. If you want to attach license file, do not forget to add it to `files`.

Also I don't know who from https://github.com/jacklund/kafka_ex/graphs/contributors actual contributors, if they part of your team add them to `contributors` list.

More info: https://hex.pm/docs/publish