### PR TITLE
Stream by calling send instead of inline recursion

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -201,7 +201,7 @@ defmodule KafkaEx do
 
     {:ok, pid}  = GenEvent.start_link
     :ok         = GenEvent.add_handler(pid, handler, [])
-    send(worker_name, {:start_streaming, topic, partition, offset, pid, handler})
+    send(worker_name, {:stream, topic, partition, offset, pid, handler, 0})
     GenEvent.stream(pid)
   end
 

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -199,10 +199,15 @@ defmodule KafkaEx do
     offset      = Keyword.get(opts, :offset, 0)
     handler     = Keyword.get(opts, :handler, KafkaExHandler)
 
-    {:ok, pid}  = GenEvent.start_link
-    :ok         = GenEvent.add_handler(pid, handler, [])
-    send(worker_name, {:stream, topic, partition, offset, pid, handler, 0})
-    GenEvent.stream(pid)
+    stream      = GenServer.call(worker_name, {:create_stream, handler})
+    send(worker_name, {:start_streaming, topic, partition, offset, handler})
+    stream
+  end
+
+  @spec stop_streaming(Keyword.t) :: :ok
+  def stop_streaming(opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, KafkaEx.Server)
+    send(worker_name, :stop_streaming)
   end
 
 #OTP API

--- a/lib/kafka_ex/metadata.ex
+++ b/lib/kafka_ex/metadata.ex
@@ -53,7 +53,7 @@ defmodule KafkaEx.Metadata do
   end
 
   defp has_leader_not_available?(metadata) do
-    Enum.any?(Enum.map(metadata.topics, fn({topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
+    Enum.any?(Enum.map(metadata.topics, fn({_topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
   end
 
   # Note: need to check for :leader_not_available for the topics, and wait until error clears to return

--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -17,7 +17,7 @@ defmodule KafkaEx.NetworkClient do
 
   def send_request(client, [{host, port}|rest], request_fn, timeout, return_response) do
     request = request_fn.(client.correlation_id, client.client_id)
-    case send_to_host(client, host, port, request, timeout) do
+    case send_to_host(client, host, port, request) do
       {:error, reason} ->
         case rest do
           [] -> raise "Error sending request: #{reason}"
@@ -55,23 +55,23 @@ defmodule KafkaEx.NetworkClient do
     end
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_list(port) do
-    send_to_host(client, host, to_string(port), request, timeout)
+  defp send_to_host(client, host, port, request) when is_list(port) do
+    send_to_host(client, host, to_string(port), request)
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_binary(port) do
-    send_to_host(client, host, String.to_integer(port), request, timeout)
+  defp send_to_host(client, host, port, request) when is_binary(port) do
+    send_to_host(client, host, String.to_integer(port), request)
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_list(host) do
-    send_to_host(client, to_string(host), port, request, timeout)
+  defp send_to_host(client, host, port, request) when is_list(host) do
+    send_to_host(client, to_string(host), port, request)
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_binary(host) and is_integer(port) do
+  defp send_to_host(client, host, port, request) when is_binary(host) and is_integer(port) do
     case get_socket(client, host, port) do
       {:error, reason} -> {:error, reason}
       {client, socket} ->
-        case do_send(socket, request, timeout) do
+        case do_send(socket, request) do
           :ok -> client
           error -> error
         end
@@ -97,7 +97,7 @@ defmodule KafkaEx.NetworkClient do
     end
   end
 
-  defp do_send(socket, request, timeout) do
+  defp do_send(socket, request) do
     :gen_tcp.send(socket, request)
   end
 

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -13,7 +13,7 @@ defmodule KafkaEx.Protocol.Fetch do
          1 :: 32, partition :: 32, offset :: 64, max_bytes :: 32 >>
   end
 
-  def parse_response(<< _correlation_id :: 32, num_topics :: 32, rest :: binary>> = a) do
+  def parse_response(<< _correlation_id :: 32, num_topics :: 32, rest :: binary>>) do
     parse_topics(%{}, num_topics, rest)
     |> generate_result
   end

--- a/test/integration/metadata_test.exs
+++ b/test/integration/metadata_test.exs
@@ -19,7 +19,7 @@ defmodule KafkaEx.Integration.Metadata.Test do
     client = KafkaEx.NetworkClient.new("test")
     topic = TestHelper.generate_random_string
 
-    {metadata, client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
+    {metadata, _client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
 
     broker = KafkaEx.Metadata.broker_for_topic(metadata, topic)
     assert broker == metadata.brokers[0]
@@ -30,7 +30,7 @@ defmodule KafkaEx.Integration.Metadata.Test do
     client = KafkaEx.NetworkClient.new("test")
     topic = TestHelper.generate_random_string
 
-    {metadata, client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
-    refute Enum.any?(Enum.map(metadata.topics, fn({topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
+    {metadata, _client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
+    refute Enum.any?(Enum.map(metadata.topics, fn({_topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
   end
 end


### PR DESCRIPTION
This returns after retrieving a single fetch and queuing another stream request.
Also, I added a sleep when we get an empty fetch, which is recommended by Kafka.
(Sleep is 1 sec, which is what the Kafka client uses, but we can adjust it if we see fit)