### PR TITLE
Add ability to stop streaming

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -201,7 +201,7 @@ defmodule KafkaEx do
 
     {:ok, pid}  = GenEvent.start_link
     :ok         = GenEvent.add_handler(pid, handler, [])
-    send(worker_name, {:start_streaming, topic, partition, offset, pid, handler})
+    send(worker_name, {:stream, topic, partition, offset, pid, handler, 0})
     GenEvent.stream(pid)
   end
 

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -199,10 +199,15 @@ defmodule KafkaEx do
     offset      = Keyword.get(opts, :offset, 0)
     handler     = Keyword.get(opts, :handler, KafkaExHandler)
 
-    {:ok, pid}  = GenEvent.start_link
-    :ok         = GenEvent.add_handler(pid, handler, [])
-    send(worker_name, {:stream, topic, partition, offset, pid, handler, 0})
-    GenEvent.stream(pid)
+    stream      = GenServer.call(worker_name, {:create_stream, handler})
+    send(worker_name, {:start_streaming, topic, partition, offset, handler})
+    stream
+  end
+
+  @spec stop_streaming(Keyword.t) :: :ok
+  def stop_streaming(opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, KafkaEx.Server)
+    send(worker_name, :stop_streaming)
   end
 
 #OTP API

--- a/lib/kafka_ex/metadata.ex
+++ b/lib/kafka_ex/metadata.ex
@@ -53,7 +53,7 @@ defmodule KafkaEx.Metadata do
   end
 
   defp has_leader_not_available?(metadata) do
-    Enum.any?(Enum.map(metadata.topics, fn({topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
+    Enum.any?(Enum.map(metadata.topics, fn({_topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
   end
 
   # Note: need to check for :leader_not_available for the topics, and wait until error clears to return

--- a/lib/kafka_ex/metadata.ex
+++ b/lib/kafka_ex/metadata.ex
@@ -60,7 +60,8 @@ defmodule KafkaEx.Metadata do
   @retry_count 3
   def update_metadata(metadata, client, topic_list, retry_count \\ @retry_count) do
     request_fn = KafkaEx.Protocol.Metadata.create_request_fn(topic_list)
-    case KafkaEx.NetworkClient.send_request(client, broker_list(metadata), request_fn) do
+    client = KafkaEx.NetworkClient.send_request(client, broker_list(metadata), request_fn)
+    case KafkaEx.NetworkClient.get_response(client) do
       {:error, reason} -> {:error, reason}
       {client, response} ->
         from_broker = KafkaEx.Protocol.Metadata.parse_response(response)

--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -17,7 +17,7 @@ defmodule KafkaEx.NetworkClient do
 
   def send_request(client, [{host, port}|rest], request_fn, timeout, return_response) do
     request = request_fn.(client.correlation_id, client.client_id)
-    case send_to_host(client, host, port, request, timeout) do
+    case send_to_host(client, host, port, request) do
       {:error, reason} ->
         case rest do
           [] -> raise "Error sending request: #{reason}"
@@ -55,23 +55,23 @@ defmodule KafkaEx.NetworkClient do
     end
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_list(port) do
-    send_to_host(client, host, to_string(port), request, timeout)
+  defp send_to_host(client, host, port, request) when is_list(port) do
+    send_to_host(client, host, to_string(port), request)
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_binary(port) do
-    send_to_host(client, host, String.to_integer(port), request, timeout)
+  defp send_to_host(client, host, port, request) when is_binary(port) do
+    send_to_host(client, host, String.to_integer(port), request)
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_list(host) do
-    send_to_host(client, to_string(host), port, request, timeout)
+  defp send_to_host(client, host, port, request) when is_list(host) do
+    send_to_host(client, to_string(host), port, request)
   end
 
-  defp send_to_host(client, host, port, request, timeout) when is_binary(host) and is_integer(port) do
+  defp send_to_host(client, host, port, request) when is_binary(host) and is_integer(port) do
     case get_socket(client, host, port) do
       {:error, reason} -> {:error, reason}
       {client, socket} ->
-        case do_send(socket, request, timeout) do
+        case do_send(socket, request) do
           :ok -> client
           error -> error
         end
@@ -97,7 +97,7 @@ defmodule KafkaEx.NetworkClient do
     end
   end
 
-  defp do_send(socket, request, timeout) do
+  defp do_send(socket, request) do
     :gen_tcp.send(socket, request)
   end
 

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -13,7 +13,7 @@ defmodule KafkaEx.Protocol.Fetch do
          1 :: 32, partition :: 32, offset :: 64, max_bytes :: 32 >>
   end
 
-  def parse_response(<< _correlation_id :: 32, num_topics :: 32, rest :: binary>> = a) do
+  def parse_response(<< _correlation_id :: 32, num_topics :: 32, rest :: binary>>) do
     parse_topics(%{}, num_topics, rest)
     |> generate_result
   end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -15,28 +15,30 @@ defmodule KafkaEx.Server do
     {:ok, {metadata, client, nil}}
   end
 
-  defp send_request(metadata, client, topic, partition, request_fn, parser, timeout \\ 100, return_response \\ true) do
+  defp send_request(metadata, client, topic, partition, request_fn, parser) do
     {metadata, client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
 
     broker = KafkaEx.Metadata.broker_for_topic(metadata, topic, partition)
     if broker == nil, do: raise "No broker found for topic #{topic}"
 
-    if return_response do
-      {client, response} = KafkaEx.NetworkClient.send_request(client, [broker], request_fn, timeout, return_response)
-      if parser do
-        {metadata, client, parser.(response)}
-      else
-        {metadata, client, response}
-      end
+    client = KafkaEx.NetworkClient.send_request(client, [broker], request_fn)
+    {metadata, client}
+  end
+
+  defp send_request_and_return_response(metadata, client, topic, partition, request_fn, parser, timeout \\ 100) do
+    {metadata, client} = send_request(metadata, client, topic, partition, request_fn, parser)
+
+    {client, response} = KafkaEx.NetworkClient.get_response(client, timeout)
+    if parser do
+      {metadata, client, parser.(response)}
     else
-      client = KafkaEx.NetworkClient.send_request(client, [broker], request_fn, timeout, return_response)
-      {metadata, client}
+      {metadata, client, response}
     end
   end
 
   def handle_call({:produce, topic, partition, value, key, required_acks, timeout}, _from, {metadata, client, event_pid}) do
     request_fn = KafkaEx.Protocol.Produce.create_request_fn(topic, partition, value, key, required_acks, timeout)
-    {metadata, client, response} = send_request(metadata, client, topic, partition, request_fn, nil, timeout)
+    {metadata, client, response} = send_request_and_return_response(metadata, client, topic, partition, request_fn, nil, timeout)
     parsed_response = case required_acks do
       0 -> :ok
       _ -> KafkaEx.Protocol.Produce.parse_response(response)
@@ -46,13 +48,13 @@ defmodule KafkaEx.Server do
 
   def handle_call({:fetch, topic, partition, offset, wait_time, min_bytes, max_bytes}, _from, {metadata, client, event_pid}) do
     request_fn = KafkaEx.Protocol.Fetch.create_request_fn(topic, partition, offset, wait_time, min_bytes, max_bytes)
-    {metadata, client, response} = send_request(metadata, client, topic, partition, request_fn, &KafkaEx.Protocol.Fetch.parse_response/1)
+    {metadata, client, response} = send_request_and_return_response(metadata, client, topic, partition, request_fn, &KafkaEx.Protocol.Fetch.parse_response/1)
     {:reply, response, {metadata, client, event_pid}}
   end
 
   def handle_call({:offset, topic, partition, time}, _from, {metadata, client, event_pid}) do
     request_fn = KafkaEx.Protocol.Offset.create_request_fn(topic, partition, time)
-    {metadata, client, response} = send_request(metadata, client, topic, partition, request_fn, &KafkaEx.Protocol.Offset.parse_response/1)
+    {metadata, client, response} = send_request_and_return_response(metadata, client, topic, partition, request_fn, &KafkaEx.Protocol.Offset.parse_response/1)
     {:reply, response, {metadata, client, event_pid}}
   end
 
@@ -97,7 +99,7 @@ defmodule KafkaEx.Server do
 
   defp start_stream(pid, metadata, client, handler, topic, partition, offset) do
     request_fn = KafkaEx.Protocol.Fetch.create_request_fn(topic, partition, offset, @wait_time, @min_bytes, @max_bytes)
-    {metadata, client} = send_request(metadata, client, topic, partition, request_fn, nil, 100, false)
+    {metadata, client} = send_request(metadata, client, topic, partition, request_fn, nil)
     receive do
       {:tcp, _, data} ->
         {:ok, response} = KafkaEx.Protocol.Fetch.parse_response(data)

--- a/test/integration/metadata_test.exs
+++ b/test/integration/metadata_test.exs
@@ -19,7 +19,7 @@ defmodule KafkaEx.Integration.Metadata.Test do
     client = KafkaEx.NetworkClient.new("test")
     topic = TestHelper.generate_random_string
 
-    {metadata, client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
+    {metadata, _client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
 
     broker = KafkaEx.Metadata.broker_for_topic(metadata, topic)
     assert broker == metadata.brokers[0]
@@ -30,7 +30,7 @@ defmodule KafkaEx.Integration.Metadata.Test do
     client = KafkaEx.NetworkClient.new("test")
     topic = TestHelper.generate_random_string
 
-    {metadata, client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
-    refute Enum.any?(Enum.map(metadata.topics, fn({topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
+    {metadata, _client} = KafkaEx.Metadata.add_topic(metadata, client, topic)
+    refute Enum.any?(Enum.map(metadata.topics, fn({_topic, values}) -> values.error_code end), fn(error) -> error == :leader_not_available end)
   end
 end


### PR DESCRIPTION
This adds the ability to stop and restart streaming. Stopping is accomplished by calling `KafkaEx.stop_streaming`, and restarted by calling `KafkaEx.stream` again. 