### PR TITLE
Move modules around in place of funs and refactor send_request.

### DIFF
--- a/lib/kafka_ex/metadata.ex
+++ b/lib/kafka_ex/metadata.ex
@@ -59,11 +59,11 @@ defmodule KafkaEx.Metadata do
   # Note: need to check for :leader_not_available for the topics, and wait until error clears to return
   @retry_count 3
   def update_metadata(metadata, client, topic_list, retry_count \\ @retry_count) do
-    request_fn = KafkaEx.Protocol.Metadata.create_request_fn(topic_list)
-    client = KafkaEx.NetworkClient.send_request(client, broker_list(metadata), request_fn)
+    client = KafkaEx.NetworkClient.send_request(client, broker_list(metadata), [topic_list], KafkaEx.Protocol.Metadata)
     case KafkaEx.NetworkClient.get_response(client) do
       {:error, reason} -> {:error, reason}
       {client, response} ->
+        #response can be {:error, :timeout} need to fix
         from_broker = KafkaEx.Protocol.Metadata.parse_response(response)
         if has_leader_not_available?(from_broker) && retry_count > 0 do
           :timer.sleep(100)

--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -13,8 +13,8 @@ defmodule KafkaEx.NetworkClient do
     %{client | correlation_id: client.correlation_id + 1}
   end
 
-  def send_request(client, brokers, request_fn) do
-    request = request_fn.(client.correlation_id, client.client_id)
+  def send_request(client, brokers, data, protocol_mod) do
+    request = apply(protocol_mod, :create_request, [client.correlation_id, client.client_id| data])
     send_created_request(client, brokers, request)
   end
 

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -1,12 +1,4 @@
 defmodule KafkaEx.Protocol.Fetch do
-  def create_request_fn(topic, partition, offset, wait_time, min_bytes, max_bytes) do
-    fn(correlation_id, client_id) ->
-      KafkaEx.Protocol.create_request(:fetch, correlation_id, client_id) <>
-        << -1 :: 32, wait_time :: 32, min_bytes :: 32, 1 :: 32, byte_size(topic) :: 16, topic :: binary,
-           1 :: 32, partition :: 32, offset :: 64, max_bytes :: 32 >>
-    end
-  end
-
   def create_request(correlation_id, client_id, topic, partition, offset, wait_time, min_bytes, max_bytes) do
     KafkaEx.Protocol.create_request(:fetch, correlation_id, client_id) <>
       << -1 :: 32, wait_time :: 32, min_bytes :: 32, 1 :: 32, byte_size(topic) :: 16, topic :: binary,

--- a/lib/kafka_ex/protocol/offset.ex
+++ b/lib/kafka_ex/protocol/offset.ex
@@ -1,11 +1,4 @@
 defmodule KafkaEx.Protocol.Offset do
-  def create_request_fn(topic, partition, time) do
-    fn(correlation_id, client_id) ->
-      KafkaEx.Protocol.create_request(:offset, correlation_id, client_id) <>
-        << -1 :: 32, 1 :: 32, byte_size(topic) :: 16, topic :: binary, 1 :: 32, partition :: 32, parse_time(time) :: 64, 1 :: 32>>
-    end
-  end
-
   def create_request(correlation_id, client_id, topic, partition, time) do
     KafkaEx.Protocol.create_request(:offset, correlation_id, client_id) <>
       << -1 :: 32, 1 :: 32, byte_size(topic) :: 16, topic :: binary, 1 :: 32, partition :: 32, parse_time(time) :: 64, 1 :: 32>>

--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -1,13 +1,4 @@
 defmodule KafkaEx.Protocol.Produce do
-  def create_request_fn(topic, partition, value, key, required_acks, timeout) do
-    fn(correlation_id, client_id) ->
-      message_set = KafkaEx.Util.create_message_set(value, key)
-      KafkaEx.Protocol.create_request(:produce, correlation_id, client_id) <>
-        << required_acks :: 16, timeout :: 32, 1 :: 32, byte_size(topic) :: 16, topic :: binary, 1 :: 32, partition :: 32, byte_size(message_set) :: 32 >> <>
-        message_set
-    end
-  end
-
   def create_request(correlation_id, client_id, topic, partition, value, key, required_acks, timeout) do
     message_set = KafkaEx.Util.create_message_set(value, key)
     KafkaEx.Protocol.create_request(:produce, correlation_id, client_id) <>
@@ -19,6 +10,8 @@ defmodule KafkaEx.Protocol.Produce do
     parse_topics(%{}, num_topics, rest)
     |> generate_result
   end
+
+  def parse_response(unknown), do: unknown
 
   defp generate_result({:ok, response_map, _rest}) do
     {:ok, response_map}

--- a/test/network_client_test.exs
+++ b/test/network_client_test.exs
@@ -2,6 +2,10 @@ defmodule KafkaEx.NetworkClient.Test do
   use ExUnit.Case
   import Mock
 
+  defmodule FakeProtocol do
+    def create_request(_, _, data), do: data
+  end
+
   test "format_host returns Erlang IP address format if IP address string is specified" do
     assert {100, 20, 3, 4} == KafkaEx.NetworkClient.format_host("100.20.3.4")
   end
@@ -23,12 +27,19 @@ defmodule KafkaEx.NetworkClient.Test do
 
   test "send_request creates and sends the specified request" do
     client = KafkaEx.NetworkClient.new("test")
-    request_fn = fn(correlation_id, client_id) -> "request" end
     with_mock :gen_tcp, [:unstick], [connect: fn(_, _, _) -> {:ok, :socket} end,
                                      send: fn(_, _) -> :ok end] do
-      client = KafkaEx.NetworkClient.send_request(client, [{"foo", 9092}], request_fn)
+      client = KafkaEx.NetworkClient.send_request(client, [{"foo", 9092}], ["request"], FakeProtocol)
       assert called :gen_tcp.connect(to_char_list("foo"), 9092, [:binary, {:packet, 4}])
       assert called :gen_tcp.send(:socket, "request")
+    end
+  end
+
+  test "send_request increments correlation_id" do
+    client = Map.put(KafkaEx.NetworkClient.new("test"), :correlation_id, 1)
+    with_mock :gen_tcp, [:unstick], [connect: fn(_, _, _) -> {:ok, :socket} end, send: fn(_, "request") -> :ok end] do
+      client = KafkaEx.NetworkClient.send_request(client, [{"foo", 9092}], ["request"], FakeProtocol)
+      assert client.correlation_id == 2
     end
   end
 end

--- a/test/protocol/metadata_test.exs
+++ b/test/protocol/metadata_test.exs
@@ -1,17 +1,21 @@
 defmodule KafkaEx.Protocol.Metadata.Test do
   use ExUnit.Case, async: true
 
-  test "create_request_fn with no topics creates a valid metadata request" do
+  test "create_request with no topics creates a valid metadata request" do
     good_request = << 3 :: 16, 0 :: 16, 1 :: 32, 3 :: 16, "foo" :: binary, 0 :: 32 >>
-    request_fn = KafkaEx.Protocol.Metadata.create_request_fn([])
-    request = request_fn.(1, "foo")
+    request = KafkaEx.Protocol.Metadata.create_request(1, "foo", [])
     assert request == good_request
   end
 
-  test "create_request_fn with a single topic creates a valid metadata request" do
+  test "create_request with a single topic creates a valid metadata request" do
     good_request = << 3 :: 16, 0 :: 16, 1 :: 32, 3 :: 16, "foo" :: binary, 1 :: 32, 3 :: 16, "bar" :: binary >>
-    request_fn = KafkaEx.Protocol.Metadata.create_request_fn(["bar"])
-    request = request_fn.(1, "foo")
+    request = KafkaEx.Protocol.Metadata.create_request(1, "foo", ["bar"])
+    assert request == good_request
+  end
+
+  test "create_request with a multiple topics creates a valid metadata request" do
+    good_request = << 3 :: 16, 0 :: 16, 1 :: 32, 3 :: 16, "foo" :: binary, 3 :: 32, 3 :: 16, "bar" :: binary, 3 :: 16, "baz" :: binary, 4 :: 16, "food" :: binary >>
+    request = KafkaEx.Protocol.Metadata.create_request(1, "foo", ["bar", "baz", "food"])
     assert request == good_request
   end
 


### PR DESCRIPTION
I merged `send_request_and_return_response` and `send_request` into a single function, I am passing the module name around instead of a fun, that removes duplication in a couple of places.