### PR TITLE
rename config key from KafkaEx to :kafka_ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mix deps.get
 
 In your config/config.exs add the list of kafka brokers as below:
 ```elixir
-config KafkaEx,
+config :kafka_ex,
   brokers: [{HOST, PORT}]
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 use Mix.Config
-  config KafkaEx,
+  config :kafka_ex,
   brokers: [
-    {"localhost", 9092}
+    {"sf-jrotenb-mac", 9092}
   ]

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -15,7 +15,7 @@ defmodule KafkaEx do
   """
   @spec create_worker(atom) :: Supervisor.on_start_child
   def create_worker(name) do
-    uris = Application.get_env(KafkaEx, :brokers)
+    uris = Application.get_env(:kafka_ex, :brokers)
     Supervisor.start_child(KafkaEx.Supervisor, [uris, name])
   end
 
@@ -228,7 +228,7 @@ defmodule KafkaEx do
 #OTP API
   def start(_type, _args) do
     {:ok, pid} = KafkaEx.Supervisor.start_link
-    uris       = Application.get_env(KafkaEx, :brokers)
+    uris       = Application.get_env(:kafka_ex, :brokers)
     case KafkaEx.create_worker(KafkaEx.Server, uris) do
       {:error, reason} -> {:error, reason}
       {:ok, _}         -> {:ok, pid}


### PR DESCRIPTION
The config key should match the application name so that configs can be pulled correctly when running a built release (created via exrm).