### PR TITLE
Bugfixes

### DIFF
--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -35,6 +35,8 @@ defmodule KafkaEx.Protocol.Metadata do
     defstruct error_code: 0, partition_id: 0, leader: -1, replicas: [], isrs: []
   end
 
+  def create_request(correlation_id, client_id, ""), do: KafkaEx.Protocol.create_request(:metadata, correlation_id, client_id) <> << 0 :: 32-signed >>
+
   def create_request(correlation_id, client_id, topic) when is_binary(topic), do: create_request(correlation_id, client_id, [topic])
 
   def create_request(correlation_id, client_id, topics) when is_list(topics) do

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -191,8 +191,11 @@ defmodule KafkaEx.Server do
     {brokers_to_keep, brokers_to_remove} = Enum.partition(brokers, fn(broker) ->
       Enum.find_value(metadata_brokers, &(broker.host == &1.host && broker.port == &1.port))
     end)
-    Enum.each(brokers_to_remove, &KafkaEx.NetworkClient.close_socket/1)
-    brokers_to_keep
+    case length(brokers_to_keep) do
+      0 -> brokers_to_remove
+      _ -> Enum.each(brokers_to_remove, fn(broker) -> KafkaEx.NetworkClient.close_socket(broker.socket) end)
+        brokers_to_keep
+    end
   end
 
   defp add_new_brokers(brokers, []), do: brokers

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -77,6 +77,13 @@ defmodule KafkaEx.Integration.Test do
   end
 
   #metadata
+  test "metadata works" do
+    random_string = TestHelper.generate_random_string
+    Enum.each(1..10, fn _ -> KafkaEx.produce(random_string, 0, "hey foo", worker_name: KafkaEx.Server, required_acks: 1) end)
+
+    refute Enum.empty?(Enum.flat_map(KafkaEx.metadata.topic_metadatas, fn(metadata) -> metadata.partition_metadatas end))
+  end
+
   test "metadata for a non-existing topic creates a new topic" do
     random_string = TestHelper.generate_random_string
     random_topic_metadata = Enum.find(KafkaEx.metadata(topic: random_string).topic_metadatas, &(&1.topic == random_string))


### PR DESCRIPTION
Fixes wrongly balancing out nodes when metadata is empty.
Fixes passing broker struct instead of socket when attempting to balance out a node.
Fix/Ensure fetching all metadata works.