### PR TITLE
Expose metadata_update_interval, consumer_group_update_interval, and.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
   config :kafka_ex,
     brokers: [
-      {"192.168.59.104", 49156}
+      {"localhost", 9092}
     ],
-    consumer_group: "kafka_ex"
+    consumer_group: false

--- a/lib/kafka_ex/protocol/offset_fetch.ex
+++ b/lib/kafka_ex/protocol/offset_fetch.ex
@@ -7,6 +7,21 @@ defmodule KafkaEx.Protocol.OffsetFetch do
   defmodule Response do
     defstruct topic: "", partitions: []
     @type t :: %Response{topic: binary, partitions: list}
+    
+    def last_offset(:topic_not_found) do
+      0
+    end
+
+    def last_offset(offset_fetch_data) do
+      case offset_fetch_data do
+        [] -> 0
+        _  -> partitions = offset_fetch_data |> hd |> Map.get(:partitions, [])
+          case partitions do
+            [] -> 0
+            _  -> partitions |> hd |> Map.get(:offset, 0)
+          end
+      end
+    end
   end
 
   def create_request(correlation_id, client_id, offset_fetch_request) do


### PR DESCRIPTION
Allow to opt out of consumer_group for Kafka < 0.8.2